### PR TITLE
Update navigator_observer.dart

### DIFF
--- a/lib/src/helper/navigator_observer.dart
+++ b/lib/src/helper/navigator_observer.dart
@@ -9,7 +9,7 @@ import 'dialog_proxy.dart';
 class SmartNavigatorObserver extends NavigatorObserver {
   @override
   void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
-    DialogProxy.contextNavigator ??= navigator?.context;
+    DialogProxy.contextNavigator = navigator?.context;
     RouteRecord.curRoute = route;
     RouteRecord.instance.push(route, previousRoute);
   }


### PR DESCRIPTION
When `navigator.context` changed `DialogProxy.contextNavigator` is dirty. so i think `DialogProxy.contextNavigator ??= navigator?.context;` need change to `DialogProxy.contextNavigator = navigator?.context;`
<img width="817" alt="image" src="https://github.com/user-attachments/assets/b24d5964-0cfa-4963-bab1-abbab762006a" />
<img width="702" alt="image" src="https://github.com/user-attachments/assets/b8302813-7b25-4d78-a6c6-1b56d112bf2b" />
